### PR TITLE
snps_accel_app: initializes the client context with the current irq event counter

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -200,6 +200,7 @@ static int snps_accel_open(struct inode *inode, struct file *filp)
 	fpriv->app = accel_app;
 	snps_accel_app_mem_init(accel_app->device, &fpriv->mem);
 
+	fpriv->handled_irq_event = atomic_read(&accel_app->irq_event);
 	filp->private_data = fpriv;
 
 	return 0;


### PR DESCRIPTION
The driver informs the client about a new interrupt (unblocks the client) in the ioctl() `SNPS_ACCEL_IOCTL_WAIT_IRQ` if the interrupt counter has changed since the last notification.
A zero value in the client context for `handled_irq_event` after open() could result in a false notification (unblock) for the first ioctl() `SNPS_ACCEL_IOCTL_WAIT_IRQ` call, if the interrupt counter is not equal to zero, for example if the client app starts and opens device second time.
To fix this, initialize the client context with the current IRQ event counter.
