### PR TITLE
Fix multicore reset sequence

### DIFF
--- a/arch/arc/boot/dts/haps_hs_npx6_8k_vpx5x2.dts
+++ b/arch/arc/boot/dts/haps_hs_npx6_8k_vpx5x2.dts
@@ -94,8 +94,7 @@
 
 		remoteproc_vpx0: remoteproc_vpx@0x18000000 {
 			compatible = "snps,vpx-rproc";
-			reg = <0x18000000 0x01000000>,
-			      <0x30001000 0x01000000>;
+			reg = <0x18000000 0x01000000>;
 			firmware-name = "Deployment_vpx.elf";
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x0 0x1>;
@@ -108,6 +107,7 @@
 			reg = <0x20000000 0x2000000>;
 			firmware-name = "Deployment_l2.elf";
 			snps,npu-cfg = <&npu_cfg0>;
+			snps,cluster-restart;
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x0>;
 			snps,arcsync-cluster-id = <0x0>;

--- a/drivers/remoteproc/snps_accel/accel_rproc.c
+++ b/drivers/remoteproc/snps_accel/accel_rproc.c
@@ -486,8 +486,15 @@ arcsync_start_core(struct snps_accel_rproc *aproc)
 	u32 status;
 	int i;
 
-	for (i = 0; i < aproc->num_cores_start; i++) {
+	/*
+	 * Assert reset line for all cores before initialization to enable setup for
+	 * all cores regardless of core reset configuration
+	 */
+	for (i = 0; i < aproc->num_cores_start; i++)
 		fn->reset(ctrl, aproc->cluster_id, aproc->core_id[i], ARCSYNC_RESET_ASSERT);
+	
+	/* Setup all cores */
+	for (i = 0; i < aproc->num_cores_start; i++) {
 		fn->set_ivt(ctrl, aproc->cluster_id, aproc->core_id[i], aproc->ivt_base);
 		status = fn->get_status(ctrl, aproc->cluster_id, aproc->core_id[i]);
 		if (aproc->ctrl.has_pmu && (status & ARCSYNC_CORE_POWERDOWN)) {
@@ -502,9 +509,15 @@ arcsync_start_core(struct snps_accel_rproc *aproc)
 		} else {
 			fn->clk_ctrl(ctrl, aproc->cluster_id, aproc->core_id[i], ARCSYNC_CLK_EN);
 		}
-		fn->reset(ctrl, aproc->cluster_id, aproc->core_id[i], ARCSYNC_RESET_DEASSERT);
-		fn->start(ctrl, aproc->cluster_id, aproc->core_id[i]);
 	}
+
+	/* Deassert reset line for all cores to apply setup for all cores */
+	for (i = 0; i < aproc->num_cores_start; i++)
+		fn->reset(ctrl, aproc->cluster_id, aproc->core_id[i], ARCSYNC_RESET_DEASSERT);
+
+	/* Start all cores */
+	for (i = 0; i < aproc->num_cores_start; i++)
+		fn->start(ctrl, aproc->cluster_id, aproc->core_id[i]);
 
 	return 0;
 }

--- a/drivers/remoteproc/snps_accel/accel_rproc.c
+++ b/drivers/remoteproc/snps_accel/accel_rproc.c
@@ -27,7 +27,7 @@ static int snps_accel_rproc_prepare(struct rproc *rproc)
 	 * If npu-cfg property is specified, setup NPU Cluster Network and
 	 * powerup/reset cluster groups
 	 */
-	if (aproc->first_load) {
+	if (aproc->first_load || aproc->cluster_restart) {
 		if (aproc->data->setup_cluster)
 			aproc->data->setup_cluster(aproc);
 		aproc->first_load = 0;
@@ -396,6 +396,7 @@ static int snps_accel_rproc_probe(struct platform_device *pdev)
 	 * rproc->sysfs_read_only = true;
 	 */
 
+	aproc->cluster_restart = of_property_read_bool(of_node, "snps,cluster-restart");
 	/* Get Cores ID to work with */
 	aproc->num_cores_start = of_property_count_u32_elems(of_node, "snps,arcsync-core-id");
 	if (aproc->num_cores_start < 0) {

--- a/drivers/remoteproc/snps_accel/accel_rproc.h
+++ b/drivers/remoteproc/snps_accel/accel_rproc.h
@@ -105,6 +105,7 @@ struct snps_accel_rproc_ctrl {
  * @device: rproc device struct
  * @num_mems: number of mem regions to map before loading elf
  * @first_load: flag that indicates first start of processors
+ * @cluster_restart: each time (not once) setup/reset entire cluster for rproc entry start request
  * @cluster_id: cluster id of the processor to start as it seen by ARCSync
  * @num_cores_start: number of cores to work with (power up/reset/start)
  * @core_id: core number (or array of core numbers) inside the cluster to start
@@ -119,6 +120,7 @@ struct snps_accel_rproc {
 	struct device *device;
 	u32 num_mems;
 	u32 first_load;
+	u32 cluster_restart;
 	u32 cluster_id;
 	s32 num_cores_start;
 	u32 *core_id;


### PR DESCRIPTION
This set of patches resolves two issues:
-  fixes multicore reset sequence
-  introduces ```snps,cluster-restart``` option to re-define default where the full cluster setup is performed only during the first start
This PR prepared as a second version for https://github.com/foss-for-synopsys-dwc-arc-processors/snps-accel-linux/pull/3