### PR TITLE
Add NPX cluster power down and interconnect skip support

### DIFF
--- a/arch/arc/boot/dts/haps_hs_npx6_4k_vpx.dts
+++ b/arch/arc/boot/dts/haps_hs_npx6_4k_vpx.dts
@@ -75,7 +75,8 @@
 
 	npu_cfg0: npu_cfg@d3000000 {
 		reg = <0x0 0xd3000000 0x0 0xF4000>;
-		snps,npu-slice-num = <2>;
+		snps,npu-slice-num = <1>;
+		snps,skip-cln-setup;
 	};
 
 	arcsync0: arcsync@d4000000 {
@@ -97,31 +98,28 @@
 			reg = <0x18000000 0x01000000>;
 			firmware-name = "Deployment_vpx.elf";
 			snps,arcsync-ctrl = <&arcsync0>;
-			snps,arcsync-core-id = <0x0 0x1>;
+			snps,arcsync-core-id = <0x0>;
 			snps,arcsync-cluster-id = <0x1>;
-			snps,auto-boot;
 		};
 
 		remoteproc_npx0: remoteproc_npx@0x5000000 {
 			compatible = "snps,npx-rproc";
 			reg = <0x20000000 0x2000000>;
 			firmware-name = "Deployment_l2.elf";
-			snps,npu-cfg = <&npu_cfg0>;
-			snps,cluster-restart;
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x0>;
 			snps,arcsync-cluster-id = <0x0>;
-			snps,auto-boot;
 		};
 
 		remoteproc_npx1: remoteproc_npx@0x8000000 {
 			compatible = "snps,npx-rproc";
 			reg = <0x10000000 0x2000000>;
+			snps,npu-cfg = <&npu_cfg0>;
+			snps,cluster-restart;
 			firmware-name = "Deployment_l1.elf";
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x1>;
 			snps,arcsync-cluster-id = <0x0>;
-			snps,auto-boot;
 		};
 
 		app_npx2: app_npx@2 {
@@ -130,6 +128,5 @@
 			snps,arcsync-ctrl = <&arcsync0>;
 			interrupts = <24>;
 		};
-
 	};
 };

--- a/arch/arc/boot/dts/haps_hs_npx6_4k_vpx5x2.dts
+++ b/arch/arc/boot/dts/haps_hs_npx6_4k_vpx5x2.dts
@@ -75,7 +75,8 @@
 
 	npu_cfg0: npu_cfg@d3000000 {
 		reg = <0x0 0xd3000000 0x0 0xF4000>;
-		snps,npu-slice-num = <2>;
+		snps,npu-slice-num = <1>;
+		snps,skip-cln-setup;
 	};
 
 	arcsync0: arcsync@d4000000 {
@@ -97,9 +98,8 @@
 			reg = <0x18000000 0x01000000>;
 			firmware-name = "Deployment_vpx.elf";
 			snps,arcsync-ctrl = <&arcsync0>;
-			snps,arcsync-core-id = <0x0>;
+			snps,arcsync-core-id = <0x0 0x1>;
 			snps,arcsync-cluster-id = <0x1>;
-			snps,auto-boot;
 		};
 
 		remoteproc_npx0: remoteproc_npx@0x5000000 {
@@ -107,10 +107,10 @@
 			reg = <0x20000000 0x2000000>;
 			firmware-name = "Deployment_l2.elf";
 			snps,npu-cfg = <&npu_cfg0>;
+			snps,cluster-restart;
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x0>;
 			snps,arcsync-cluster-id = <0x0>;
-			snps,auto-boot;
 		};
 
 		remoteproc_npx1: remoteproc_npx@0x8000000 {
@@ -120,7 +120,6 @@
 			snps,arcsync-ctrl = <&arcsync0>;
 			snps,arcsync-core-id = <0x1>;
 			snps,arcsync-cluster-id = <0x0>;
-			snps,auto-boot;
 		};
 
 		app_npx2: app_npx@2 {
@@ -129,5 +128,6 @@
 			snps,arcsync-ctrl = <&arcsync0>;
 			interrupts = <24>;
 		};
+
 	};
 };

--- a/arch/arc/boot/dts/haps_hs_npx6v2x1x32k_vpx.dts
+++ b/arch/arc/boot/dts/haps_hs_npx6v2x1x32k_vpx.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2016-2014 Synopsys, Inc. (www.synopsys.com)
+ */
+/dts-v1/;
+
+/include/ "skeleton_hs.dtsi"
+
+/ {
+	model = "snps,haps_npp";
+	compatible = "snps,haps_npp";
+	#address-cells = <2>;
+	#size-cells = <2>;
+	interrupt-parent = <&core_intc>;
+
+	memory {
+		device_type = "memory";
+		/* CONFIG_LINUX_RAM_BASE needs to match low mem start */
+		reg = <0x0 0xB0000000 0x0 0x10000000	/* 1 GB low mem */
+		       0x1 0x00000000 0x0 0x40000000>;	/* 1 GB highmem */
+	};
+
+	chosen {
+		bootargs = "earlycon=uart8250,mmio32,0xd5008000,19200n8 console=ttyS0,19200n8 debug print-fatal-signals=1 drm.debug=0";
+	};
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		reserved: buffer@bc000000 {
+			compatible = "shared-dma-pool";
+			reusable;
+			reg = <0x0 0xBC000000 0x0 0x04000000>;
+			linux,cma-default;
+		};
+	};
+
+	fpga {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* only perip space at end of low mem accessible
+			  bus addr,  parent bus addr, size    */
+		ranges = <0x80000000 0x0 0x80000000 0x80000000>;
+
+		core_clk: core_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <4000000>;
+		};
+
+		core_intc: interrupt-controller {
+			compatible = "snps,archs-intc";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+		};
+
+		uart0: serial@d50080000 {
+			compatible = "ns16550a";
+			reg = <0xd5008000 0x1000>;
+			interrupts = <18>;
+			clock-frequency = <4000000>;
+			baud = <19200>;
+			reg-shift = <2>;
+			reg-io-width = <4>;
+			no-loopback-test = <1>;
+		};
+	};
+
+	npu_cfg0: npu_cfg@d3000000 {
+		reg = <0x0 0xd3000000 0x0 0xF4000>;
+		snps,npu-slice-num = <8>;
+		snps,skip-cln-setup;
+	};
+
+	arcsync0: arcsync@d4000000 {
+		compatible = "snps,arcsync";
+		reg = <0x0 0xd4000000 0x0 0x1000000>;
+		snps,host-cluster-id = <0x2>;
+		interrupts = <24>;
+	};
+
+	snps_accel@0 {
+		compatible = "snps,accel", "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0x0 0x0000000 0x0 0x80000000>;
+		ranges = <0x0 0x0 0x0 0x80000000>;
+
+		remoteproc_vpx0: remoteproc_vpx@0x18000000 {
+			compatible = "snps,vpx-rproc";
+			reg = <0x18000000 0x01000000>;
+			firmware-name = "Deployment_vpx.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x0>;
+			snps,arcsync-cluster-id = <0x1>;
+		};
+
+		remoteproc_npx0: remoteproc_npx@0x5000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x20000000 0x2000000>;
+			firmware-name = "Deployment_l2.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x0>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx1: remoteproc_npx@0x10000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x10000000 0x1000000>;
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,npu-cfg = <&npu_cfg0>;
+			snps,cluster-restart;
+			firmware-name = "Deployment_l1_c0.elf";
+			snps,arcsync-core-id = <0x1>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx2: remoteproc_npx@0x11000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x11000000 0x1000000>;
+			firmware-name = "Deployment_l1_c1.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x2>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx3: remoteproc_npx@0x12000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x12000000 0x1000000>;
+			firmware-name = "Deployment_l1_c2.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x3>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx4: remoteproc_npx@0x13000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x13000000 0x1000000>;
+			firmware-name = "Deployment_l1_c3.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x4>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx5: remoteproc_npx@0x14000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x14000000 0x1000000>;
+			firmware-name = "Deployment_l1_c4.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x5>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx6: remoteproc_npx@0x15000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x15000000 0x1000000>;
+			firmware-name = "Deployment_l1_c5.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x6>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx7: remoteproc_npx@0x16000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x16000000 0x1000000>;
+			firmware-name = "Deployment_l1_c6.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x7>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		remoteproc_npx8: remoteproc_npx@0x17000000 {
+			compatible = "snps,npx-rproc";
+			reg = <0x17000000 0x1000000>;
+			firmware-name = "Deployment_l1_c7.elf";
+			snps,arcsync-ctrl = <&arcsync0>;
+			snps,arcsync-core-id = <0x8>;
+			snps,arcsync-cluster-id = <0x0>;
+		};
+
+		app_npx2: app_npx@2 {
+			compatible = "snps,accel-app";
+			reg = <0x30000000 0x10000000>;
+			snps,arcsync-ctrl = <&arcsync0>;
+			interrupts = <24>;
+		};
+	};
+};

--- a/drivers/remoteproc/snps_accel/accel_rproc.c
+++ b/drivers/remoteproc/snps_accel/accel_rproc.c
@@ -59,6 +59,10 @@ static int snps_accel_rproc_stop(struct rproc *rproc)
 	if (aproc->data->stop_core)
 		aproc->data->stop_core(aproc);
 
+	if (aproc->cluster_restart)
+		if (aproc->data->stop_cluster)
+			aproc->data->stop_cluster(aproc);
+
 	return 0;
 }
 
@@ -553,12 +557,14 @@ static int arcsync_stop_core(struct snps_accel_rproc *aproc)
 
 static const struct snps_accel_rproc_dev_data vpx_def_conf = {
 	.setup_cluster		= NULL,
+	.stop_cluster		= NULL,
 	.start_core		= arcsync_start_core,
 	.stop_core		= arcsync_stop_core,
 };
 
 static const struct snps_accel_rproc_dev_data npx_def_conf = {
 	.setup_cluster		= npx_setup_cluster_default,
+	.stop_cluster		= npx_stop_cluster_default,
 	.start_core		= arcsync_start_core,
 	.stop_core		= arcsync_stop_core,
 };

--- a/drivers/remoteproc/snps_accel/accel_rproc.h
+++ b/drivers/remoteproc/snps_accel/accel_rproc.h
@@ -33,6 +33,7 @@ struct snps_accel_rproc_mem {
  */
 struct snps_accel_rproc_dev_data {
 	int (*setup_cluster)(struct snps_accel_rproc *aproc);
+	int (*stop_cluster)(struct snps_accel_rproc *aproc);
 	int (*start_core)(struct snps_accel_rproc *aproc);
 	int (*stop_core)(struct snps_accel_rproc *aproc);
 };
@@ -133,5 +134,6 @@ struct snps_accel_rproc {
 };
 
 int npx_setup_cluster_default(struct snps_accel_rproc *npu);
+int npx_stop_cluster_default(struct snps_accel_rproc *npu);
 
 #endif

--- a/drivers/remoteproc/snps_accel/accel_rproc.h
+++ b/drivers/remoteproc/snps_accel/accel_rproc.h
@@ -65,6 +65,7 @@ struct snps_npu_cn {
 	u32 stu_per_grp;
 	u32 safety_lvl;
 	u32 map_start;
+	u32 skip_setup;
 };
 
 /**

--- a/drivers/remoteproc/snps_accel/npx_config.c
+++ b/drivers/remoteproc/snps_accel/npx_config.c
@@ -493,6 +493,7 @@ int npx_setup_cluster_default(struct snps_accel_rproc *npu)
 	npu->cn.safety_lvl = NPU_DEF_SAFETY_LEVEL;
 	npu->cn.csm_size = NPU_DEF_CSM_SIZE;
 	npu->cn.map_start = NPX_DEF_CLN_MAP_START;
+	npu->cn.skip_setup = 0;
 
 	/* Get groups properties and update defaults */
 	of_property_read_u32(npu_cfg_np, "snps,npu-slice-num",
@@ -518,8 +519,8 @@ int npx_setup_cluster_default(struct snps_accel_rproc *npu)
 		else
 			npu->cn.num_grps = 4;
 	}
-
 	npu->cn.slice_per_grp = npu->cn.num_slices / npu->cn.num_grps;
+	npu->cn.skip_setup = of_property_read_bool(npu_cfg_np, "snps,skip-cln-setup");
 
 	dev_dbg(npu->device, "NPU slice num: %d\n", npu->cn.num_slices);
 	dev_dbg(npu->device, "Num grps: %d\n", npu->cn.num_grps);
@@ -536,12 +537,15 @@ int npx_setup_cluster_default(struct snps_accel_rproc *npu)
 		npx_powerup_cluster_grps(npu);
 	else
 		npx_clk_en_cluster_grps(npu);
+
 	/* Setup Cluster Network */
-	npx_config_l2_grp(cfg_ptr, &npu->cn);
-	for (i = 0; i < npu->cn.num_grps; i++) {
-		dev_dbg(npu->device, "Config L1 group %d\n", i);
-		npx_config_cln_grp(cfg_ptr, &npu->cn, i);
-		npx_config_remap(cfg_ptr, &npu->cn, i);
+	if (!npu->cn.skip_setup) {
+		npx_config_l2_grp(cfg_ptr, &npu->cn);
+		for (i = 0; i < npu->cn.num_grps; i++) {
+			dev_dbg(npu->device, "Config L1 group %d\n", i);
+			npx_config_cln_grp(cfg_ptr, &npu->cn, i);
+			npx_config_remap(cfg_ptr, &npu->cn, i);
+		}
 	}
 
 	iounmap(cfg_ptr);

--- a/drivers/remoteproc/snps_accel/npx_config.c
+++ b/drivers/remoteproc/snps_accel/npx_config.c
@@ -365,7 +365,27 @@ static int npx_powerup_core(struct snps_accel_rproc *aproc, u32 clid, u32 cid)
 	return count ? 0 : -EBUSY;
 }
 
-static int npx_reset_cluster_grps(struct snps_accel_rproc *aproc)
+static int npx_powerdown_core(struct snps_accel_rproc *aproc, u32 clid, u32 cid)
+{
+	struct device *ctrl = aproc->ctrl.dev;
+	const struct snps_accel_rproc_ctrl_fn *fn = &aproc->ctrl.fn;
+	int count = 10;
+
+	if (!(fn->get_status(ctrl, clid, cid) & ARCSYNC_CORE_POWERDOWN)) {
+		fn->halt(ctrl, clid, cid);
+		while (!(fn->get_status(ctrl, clid, cid) & ARCSYNC_CORE_HALTED) && --count)
+			udelay(1);
+		fn->clk_ctrl(ctrl, clid, cid, ARCSYNC_CLK_DIS);
+		fn->power_ctrl(ctrl, clid, cid, ARCSYNC_POWER_DOWN);
+		count = 10;
+		while (!(fn->get_status(ctrl, clid, cid) & ARCSYNC_CORE_POWERDOWN) && --count)
+			udelay(1);
+	}
+
+	return count ? 0 : -EBUSY;
+}
+
+static int npx_reset_cluster_grps(struct snps_accel_rproc *aproc, u32 rst_code)
 {
 	struct device *ctrl = aproc->ctrl.dev;
 	const struct snps_accel_rproc_ctrl_fn *fn = &aproc->ctrl.fn;
@@ -375,21 +395,21 @@ static int npx_reset_cluster_grps(struct snps_accel_rproc *aproc)
 
 	if (aproc->ctrl.ver == 2) {
 		fn->reset_cluster_group(ctrl, clid, ARCSYNC_NPX_L2GRP,
-					ARCSYNC_RESET_DEASSERT);
+					rst_code);
 		/* reset L2C cores inside the L2 group */
-		fn->reset(ctrl, clid, NPX_COREID_L2C0, ARCSYNC_RESET_DEASSERT);
+		fn->reset(ctrl, clid, NPX_COREID_L2C0, rst_code);
 		if (aproc->cn.num_slices >= 8)
 			fn->reset(ctrl, clid, aproc->cn.num_slices + 1,
-				  ARCSYNC_RESET_DEASSERT);
+				  rst_code);
 
 		for (grp = 0; grp < aproc->cn.num_grps; grp++) {
 			fn->reset_cluster_group(ctrl, clid, ARCSYNC_NPX_L1GRP0 + grp,
-						ARCSYNC_RESET_DEASSERT);
+						rst_code);
 			/* reset cores inside the group */
 			for (i = 0; i < aproc->cn.slice_per_grp; i++)
 				fn->reset(ctrl, clid,
 					  NPX_COREID_L1C0 + grp * aproc->cn.slice_per_grp + i,
-					  ARCSYNC_RESET_DEASSERT);
+					  rst_code);
 		}
 	}
 
@@ -432,7 +452,39 @@ static int npx_powerup_cluster_grps(struct snps_accel_rproc *aproc)
 	return 0;
 }
 
-static int npx_clk_en_cluster_grps(struct snps_accel_rproc *aproc)
+static int npx_powerdown_cluster_grps(struct snps_accel_rproc *aproc)
+{
+	struct device *ctrl = aproc->ctrl.dev;
+	const struct snps_accel_rproc_ctrl_fn *fn = &aproc->ctrl.fn;
+	u32 clid = aproc->cluster_id;
+	int slice_offset;
+	int grp;
+	int i;
+
+	if (aproc->ctrl.ver == 2) {
+		for (grp = 0; grp < aproc->cn.num_grps; grp++) {
+			fn->clk_ctrl_cluster_group(ctrl, clid,
+						   ARCSYNC_NPX_L1GRP0 + grp,
+						   ARCSYNC_CLK_DIS);
+			fn->power_ctrl_cluster_group(ctrl, clid,
+						     ARCSYNC_NPX_L1GRP0 + grp,
+						     ARCSYNC_POWER_DOWN);
+			slice_offset = grp * aproc->cn.slice_per_grp;
+			for (i = 0; i < aproc->cn.slice_per_grp; i++)
+				npx_powerdown_core(aproc, clid,
+						 NPX_COREID_L1C0 + slice_offset + i);
+		}
+		fn->clk_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L2GRP, ARCSYNC_CLK_DIS);
+		fn->power_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L2GRP, ARCSYNC_POWER_DOWN);
+		npx_powerdown_core(aproc, clid, NPX_COREID_L2C0);
+		if (aproc->cn.num_slices >= 8)
+			npx_powerdown_core(aproc, clid, aproc->cn.num_slices + 1);
+	}
+
+	return 0;
+}
+
+static int npx_clk_ctrl_cluster_grps(struct snps_accel_rproc *aproc, u32 ctrl_val)
 {
 	struct device *ctrl = aproc->ctrl.dev;
 	const struct snps_accel_rproc_ctrl_fn *fn = &aproc->ctrl.fn;
@@ -443,17 +495,28 @@ static int npx_clk_en_cluster_grps(struct snps_accel_rproc *aproc)
 	if (aproc->ctrl.ver != 2)
 		return 0;
 
-	fn->clk_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L2GRP, ARCSYNC_CLK_EN);
-	fn->clk_ctrl(ctrl, clid, NPX_COREID_L2C0, ARCSYNC_CLK_EN);
+	fn->clk_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L2GRP, ctrl_val);
+	fn->clk_ctrl(ctrl, clid, NPX_COREID_L2C0, ctrl_val);
 	if (aproc->cn.num_slices >= 8)
-		fn->clk_ctrl(ctrl, clid, aproc->cn.num_slices + 1, ARCSYNC_CLK_EN);
+		fn->clk_ctrl(ctrl, clid, aproc->cn.num_slices + 1, ctrl_val);
 	for (grp = 0; grp < aproc->cn.num_grps; grp++) {
-		fn->clk_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L1GRP0 + grp, ARCSYNC_CLK_EN);
+		fn->clk_ctrl_cluster_group(ctrl, clid, ARCSYNC_NPX_L1GRP0 + grp, ctrl_val);
 		for (i = 0; i < aproc->cn.slice_per_grp; i++)
 			fn->clk_ctrl(ctrl, clid,
 				     NPX_COREID_L1C0 + grp * aproc->cn.slice_per_grp + i,
-				     ARCSYNC_CLK_EN);
+				     ctrl_val);
 	}
+
+	return 0;
+}
+
+int npx_stop_cluster_default(struct snps_accel_rproc *npu)
+{
+	npx_reset_cluster_grps(npu, ARCSYNC_RESET_ASSERT);
+	if (npu->ctrl.has_pmu)
+		npx_powerdown_cluster_grps(npu);
+	else
+		npx_clk_ctrl_cluster_grps(npu, ARCSYNC_CLK_DIS);
 
 	return 0;
 }
@@ -532,11 +595,11 @@ int npx_setup_cluster_default(struct snps_accel_rproc *npu)
 	dev_dbg(npu->device, "CLN map start: 0x%x\n", npu->cn.map_start);
 
 	/* Reset NPX cluster groups */
-	npx_reset_cluster_grps(npu);
+	npx_reset_cluster_grps(npu, ARCSYNC_RESET_DEASSERT);
 	if (npu->ctrl.has_pmu)
 		npx_powerup_cluster_grps(npu);
 	else
-		npx_clk_en_cluster_grps(npu);
+		npx_clk_ctrl_cluster_grps(npu, ARCSYNC_CLK_EN);
 
 	/* Setup Cluster Network */
 	if (!npu->cn.skip_setup) {


### PR DESCRIPTION

This patch series introduces enhancements to the remoteproc driver to improve power management and initialization flexibility:
- Adds logic to stop and power down the NPX cluster when the control core (identified by the ```snps,npu-cfg``` property) is stopped. This behavior is enabled only when the ```snps,cluster-restart``` property is present in the remoteproc node.
- Introduces a new boolean Device Tree property, ```snps,skip-cln-setup```, under the ```npu_cfg``` node. When present, the driver will skip interconnect (CLN) setup during the initial bring-up, allowing platforms with pre-configured interconnects to avoid redundant configuration.
- Updates DTS with new options.

These changes ensure proper integration with platforms that rely on external interconnect configuration and require full cluster reset on control core shutdown.