### PR TITLE
Synopsys Accelerator driver changes for ZynqMP ZCU104 FPGA for kernel v6.6

### DIFF
--- a/arch/arc/boot/dts/haps_hs_npp.dts
+++ b/arch/arc/boot/dts/haps_hs_npp.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2016-2014 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2016-2025 Synopsys, Inc. (www.synopsys.com)
  */
 /dts-v1/;
 
@@ -94,7 +94,8 @@
 			compatible = "snps,accel-app";
 			reg = <0x20000000 0x10000000>;
 			snps,arcsync-ctrl = <&arcsync0>;
-			interrupts = <24>;
+			snps,arcsync-irq-idx = <0>;
+			snps,dma-bits = <32>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -2,7 +2,7 @@
 /*
  * dts file for Xilinx ZynqMP
  *
- * (C) Copyright 2014 - 2021, Xilinx, Inc.
+ * (C) Copyright 2014 - 2025, Xilinx, Inc.
  *
  * Michal Simek <michal.simek@amd.com>
  *
@@ -1109,25 +1109,39 @@
 			compatible = "snps,accel", "simple-bus";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
+			/* Parent node address-celss and size-cells must be set to 2 */
+			/* 2MB shared memory: 1 - IPC memory, 2 - VPX firmware memory */
 			reg = <0x00 0x2b000000 0x00 0x200000>;
+			/* 1: 0x2B000000 - child address, 2: 0x0 0x2B000000 - parent address, 3: 0x200000 - child size */
 			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
 			#stream-id-cells = <0x01>;
+			/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
 			iommus = <&smmu 0x12c0>;
 
 			remoteproc_vpx@2B000000 {
 				compatible = "snps,vpx-rproc";
+				/* VPX firmware memory, must be the same as in the accel-ping linker script link_cmd.txt */
+				/* This size is the firmware footprint size */
 				reg = <0x2b000000 0x100000>;
 				firmware-name = "dmabuf-rw-app.elf";
 				snps,arcsync-ctrl = <&arcsync>;
 				snps,arcsync-core-id = <0x00>;
 				snps,arcsync-cluster-id = <0x01>;
+				/* Disable ARC core booting during Linux kernel booting for debugging purposes */
+				/* snps,auto-boot; */
 			};
 
 			app_vpx@0 {
 				compatible = "snps,accel-app";
+				/* IPC memory, must be the same as in SHR_MEM_START in VPX firmware */
 				reg = <0x2b100000 0x8000>;
 				snps,arcsync-ctrl = <&arcsync>;
+				/* Device tree interrupt 0x59(89) -> GIC interrupt 0x79(121) -> Host CPU interrupt 0x2C(44) */
+				/* Use irq index in arcsync interrupts array instead of the GIC irq id */
+				/* This index must be the same as the GIC interrupt 122 index in the arcsync node interrupts */
+				/* ARCsync v0c0arc_irq1_a -> VPX irq19_a in the FPGA bitfile */
 				snps,arcsync-irq-idx = <0x00>;
+				/* How many address bits the VPX master can use for DMA to system RAM */
 				snps,dma-bits = <0x1f>;
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -797,7 +797,7 @@
 			compatible = "arm,mmu-500";
 			reg = <0x0 0xfd800000 0x0 0x20000>;
 			#iommu-cells = <1>;
-			status = "disabled";
+			status = "okay";
 			#global-interrupts = <1>;
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>,
@@ -1071,6 +1071,64 @@
 				port@5 {
 					reg = <5>;
 				};
+			};
+		};
+	};
+	
+	pl-bus {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		arcsync: arcsync_top@a4000000 {
+			clock-names = "arcsync_axi_clk", "arcsync_clk";
+			clocks = <&zynqmp_clk 71>, <&zynqmp_clk 71>;
+			compatible = "snps,arcsync";
+			interrupt-names = "h0host_irq";
+			interrupt-parent = <&gic>;
+			interrupts = <0 90 4>, /* GIC interrupt 122 - 32 = 90, irq_idx = 0, this interrupt is used by ARCsync for the host */
+				<0 89 4>; /* GIC interrupt 121 - 32 = 89, irq_idx = 1 */
+			reg = <0x00 0xa4000000 0x00 0x2000000>;
+			snps,host-core-id = <0x00>;
+			snps,host-cluster-id = <0x02>;
+		};
+
+		reserved-memory {
+			#address-cells = <0x02>;
+			#size-cells = <0x02>;
+
+			buffer@0 {
+				compatible = "removed-dma-pool";
+				no-map;
+				reg = <0x00 0x2b000000 0x00 0x200000>;
+			};
+		};
+
+		snps_accel@0 {
+			compatible = "snps,accel", "simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			reg = <0x00 0x2b000000 0x00 0x200000>;
+			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
+			#stream-id-cells = <0x01>;
+			iommus = <&smmu 0x12c0>;
+
+			remoteproc_vpx@2B000000 {
+				compatible = "snps,vpx-rproc";
+				reg = <0x2b000000 0x100000>;
+				firmware-name = "dmabuf-rw-app.elf";
+				snps,arcsync-ctrl = <&arcsync>;
+				snps,arcsync-core-id = <0x00>;
+				snps,arcsync-cluster-id = <0x01>;
+			};
+
+			app_vpx@0 {
+				compatible = "snps,accel-app";
+				reg = <0x2b100000 0x8000>;
+				snps,arcsync-ctrl = <&arcsync>;
+				snps,arcsync-irq-idx = <0x00>;
+				snps,dma-bits = <0x1f>;
 			};
 		};
 	};

--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -545,9 +545,8 @@ static int snps_accel_probe(struct platform_device *pdev)
 	accel_dev->shared_base = res->start;
 	accel_dev->shared_size = resource_size(res);
 
-	dev_dbg(&pdev->dev, "shared memory start 0x%llx, size 0x%llx\n",
-			(unsigned long long)accel_dev->shared_base,
-			(unsigned long long)accel_dev->shared_size);
+	dev_dbg(&pdev->dev, "shared memory start %pa, size %pa\n",
+			&accel_dev->shared_base, &accel_dev->shared_size);
 
 	dev_set_drvdata(&pdev->dev, accel_dev);
 	ret = snps_accel_create_devs(pdev);

--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-mapping.h>
 #include <linux/fs.h>
 #include <linux/mm.h>
+#include <linux/init.h>
 #include <linux/module.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
@@ -329,6 +330,10 @@ static irqreturn_t snps_accel_app_irq_callback(int irq, void *dev)
 	atomic_inc(&accel_app->irq_event);
 	wake_up_interruptible(&accel_app->wait);
 
+	dev_dbg(accel_app->device,
+			"ARCsync interrupt callback: irq %d, irqnum 0x%x, count %u\n",
+			irq, accel_app->irq_num, atomic_read(&accel_app->irq_event));
+
 	return IRQ_HANDLED;
 }
 
@@ -358,6 +363,7 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 	struct snps_accel_device *accel_dev = dev_get_drvdata(&pdev->dev);
 	struct resource ctrl;
 	struct resource shmem;
+	u32 dma_bits = 32;
 
 	ret = snps_accel_get_ctrl_mem(node, &ctrl);
 	if (ret < 0) {
@@ -414,23 +420,37 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 	}
 
 	accel_app->device->dma_mask = pdev->dev.dma_mask;
-	ret = dma_set_coherent_mask(accel_app->device, DMA_BIT_MASK(32));
+	ret = of_property_read_u32(node, "snps,dma-bits", &dma_bits);
+	if (ret) {
+		dev_warn(accel_app->device, "dma-bits read error %d, use %u\n",
+				ret, dma_bits);
+	}
+	ret = dma_set_coherent_mask(accel_app->device, DMA_BIT_MASK(dma_bits));
 	if (ret) {
 		dev_err(accel_app->device, "No suitable coherent DMA available\n");
 		goto err_app_dev_init;
 	}
+	ret = dma_set_mask(accel_app->device, DMA_BIT_MASK(dma_bits));
+	if (ret) {
+		dev_err(accel_app->device, "No suitable DMA available\n");
+		goto err_app_dev_init;
+	}
+	dev_dbg(accel_app->device, "dma mask 0x%llx, coherent 0x%llx\n",
+			accel_app->device->dma_mask ? *accel_app->device->dma_mask : 0,
+			accel_app->device->coherent_dma_mask);
 
 	/* Add interrupt callback for ARCSync interrupt */
 	accel_app->irq_num = of_irq_get(node, 0);
+	of_property_read_u32(node, "snps,arcsync-irq-idx", &accel_app->irq_num);
 	if (accel_app->irq_num >= 0) {
 		ret = accel_app->ctrl.fn.set_interrupt_callback(accel_app->ctrl.dev,
 					accel_app->irq_num,
 					snps_accel_app_irq_callback, accel_app);
 		if (!ret) {
 			init_waitqueue_head(&accel_app->wait);
-			dev_dbg(accel_app->device, "App IRQ: %d\n", accel_app->irq_num);
+			dev_dbg(accel_app->device, "App IRQ idx: %d\n", accel_app->irq_num);
 		} else {
-			dev_warn(accel_app->device, "Not ARCSync IRQ %d\n", accel_app->irq_num);
+			dev_warn(accel_app->device, "Not ARCSync IRQ idx %d\n", accel_app->irq_num);
 			accel_app->irq_num = -EINVAL;
 		}
 	} else {
@@ -525,6 +545,10 @@ static int snps_accel_probe(struct platform_device *pdev)
 	accel_dev->shared_base = res->start;
 	accel_dev->shared_size = resource_size(res);
 
+	dev_dbg(&pdev->dev, "shared memory start 0x%llx, size 0x%llx\n",
+			(unsigned long long)accel_dev->shared_base,
+			(unsigned long long)accel_dev->shared_size);
+
 	dev_set_drvdata(&pdev->dev, accel_dev);
 	ret = snps_accel_create_devs(pdev);
 	if (ret != 0) {
@@ -588,7 +612,7 @@ err_chr:
 err_class:
 	return ret;
 }
-module_init(snps_accel_init);
+late_initcall(snps_accel_init);
 
 static void __exit snps_accel_exit(void)
 {

--- a/drivers/misc/snps_accel/snps_accel_drv.h
+++ b/drivers/misc/snps_accel/snps_accel_drv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 /*
- * Copyright (C) 2024 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2024-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #ifndef _SNPS_ACCEL_DRV_H
@@ -55,6 +55,7 @@ struct snps_accel_app {
 	resource_size_t shmem_size;
 	resource_size_t ctrl_base;
 	resource_size_t ctrl_size;
+	struct device *parent;
 };
 
 /**

--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -25,7 +25,7 @@ snps_accel_mbuf_alloc(struct snps_accel_mem_ctx *mem, size_t size,
 
 	/* Allocate buffer in direct memory */
 	page = dma_alloc_pages(dmabuf_dev, PAGE_ALIGN(size), &mbuf->da,
-			       dma_dir, GFP_KERNEL | __GFP_NOWARN);
+				dma_dir, GFP_KERNEL | __GFP_NOWARN);
 	if (!page) {
 		dev_err(mem->dev, "Failed to allocate contiguous memory for buffer\n");
 		return NULL;
@@ -61,7 +61,7 @@ snps_accel_mbuf_free(struct snps_accel_mem_ctx *mem,
 	mutex_unlock(&mem->list_lock);
 
 	dma_free_pages(mbuf->dev, mbuf->size,
-		       virt_to_page(mbuf->va),
+					virt_to_page(mbuf->va),
 					mbuf->alloc_da, dma_dir);
 
 	kfree(mbuf);
@@ -372,10 +372,8 @@ int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info)
 	info->addr = mbuf->da;
 	info->size = mbuf->size;
 
-	dev_dbg(mbuf->dev,
-			"dmabuf info: va/pa/da 0x%llx/0x%llx/0x%llx, size %zu\n",
-			(unsigned long long)mbuf->va, (unsigned long long)mbuf->pa,
-			(unsigned long long)mbuf->da, mbuf->size);
+	dev_dbg(mbuf->dev, "dmabuf info: va/pa/da %px/%pa/%pad, size %zu\n",
+			mbuf->va, &mbuf->pa, &mbuf->da, mbuf->size);
 
 	dma_buf_put(dmabuf);
 	return 0;

--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-buf.h>
@@ -17,20 +17,22 @@ snps_accel_mbuf_alloc(struct snps_accel_mem_ctx *mem, size_t size,
 	struct page *page;
 	struct snps_accel_mem_buffer *mbuf = NULL;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
+	struct device *dmabuf_dev = mem->dev->parent;
 
 	mbuf = kzalloc(sizeof(*mbuf), GFP_KERNEL);
 	if (!mbuf)
 		return NULL;
 
 	/* Allocate buffer in direct memory */
-	page = dma_alloc_pages(mem->dev, PAGE_ALIGN(size), &mbuf->da,
+	page = dma_alloc_pages(dmabuf_dev, PAGE_ALIGN(size), &mbuf->da,
 			       dma_dir, GFP_KERNEL | __GFP_NOWARN);
 	if (!page) {
 		dev_err(mem->dev, "Failed to allocate contiguous memory for buffer\n");
 		return NULL;
 	}
+	mbuf->alloc_da = mbuf->da;
 	mbuf->ctx = mem;
-	mbuf->dev = mem->dev;
+	mbuf->dev = dmabuf_dev;
 	mbuf->va = page_address(page);
 	mbuf->pa =  page_to_pfn(page) << PAGE_SHIFT;
 	mbuf->size = PAGE_ALIGN(size);
@@ -60,7 +62,7 @@ snps_accel_mbuf_free(struct snps_accel_mem_ctx *mem,
 
 	dma_free_pages(mbuf->dev, mbuf->size,
 		       virt_to_page(mbuf->va),
-		       mbuf->da, dma_dir);
+					mbuf->alloc_da, dma_dir);
 
 	kfree(mbuf);
 	snps_accel_file_priv_put(fpriv);
@@ -370,6 +372,11 @@ int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info)
 	info->addr = mbuf->da;
 	info->size = mbuf->size;
 
+	dev_dbg(mbuf->dev,
+			"dmabuf info: va/pa/da 0x%llx/0x%llx/0x%llx, size %zu\n",
+			(unsigned long long)mbuf->va, (unsigned long long)mbuf->pa,
+			(unsigned long long)mbuf->da, mbuf->size);
+
 	dma_buf_put(dmabuf);
 	return 0;
 }
@@ -385,6 +392,7 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 	struct snps_accel_mem_buffer *mbuf;
 	int ret;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
+	struct device *dmabuf_dev = mem->dev->parent;
 
 	dmabuf = dma_buf_get(fd);
 	if (IS_ERR_OR_NULL(dmabuf)) {
@@ -400,6 +408,7 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 	}
 
 	mbuf->dma_dir = DMA_BIDIRECTIONAL;
+	mbuf->dev = dmabuf_dev;
 	ret = snps_accel_dmabuf_attach_device(dmabuf, mem->dev,
 					      mbuf, mbuf->dma_dir);
 	if (ret != 0) {
@@ -412,7 +421,6 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 		goto err_notcontig;
 	}
 
-	mbuf->dev = mem->dev;
 	mbuf->fd = fd;
 	mbuf->dmabuf = dmabuf;
 	mbuf->size = dmabuf->size;

--- a/drivers/misc/snps_accel/snps_accel_mem.h
+++ b/drivers/misc/snps_accel/snps_accel_mem.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 /*
- * Copyright (C) 2024 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2024-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #ifndef _SNPS_ACCEL_MEM_H
@@ -31,6 +31,7 @@ struct snps_accel_mem_buffer {
 	struct dma_buf *dmabuf;
 	enum dma_data_direction dma_dir;
 	int fd;
+	dma_addr_t alloc_da;
 	dma_addr_t da;
 	void *va;
 	phys_addr_t pa;

--- a/drivers/misc/snps_accel/snps_arcsync.c
+++ b/drivers/misc/snps_accel/snps_arcsync.c
@@ -660,7 +660,7 @@ arcsync_get_interrupt(struct arcsync_device *arcsync, u32 idx)
  */
 static int
 arcsync_set_interrupt_callback(struct device *dev, u32 idx,
-			       intr_callback_t func, void *data)
+			intr_callback_t func, void *data)
 {
 	struct arcsync_callback *cb;
 	struct arcsync_interrupt *intr;
@@ -696,7 +696,7 @@ arcsync_set_interrupt_callback(struct device *dev, u32 idx,
  */
 static int
 arcsync_remove_interrupt_callback(struct device *dev, u32 idx,
-				  void *data)
+				void *data)
 {
 	struct arcsync_interrupt *intr;
 	struct arcsync_callback *cb;

--- a/drivers/misc/snps_accel/snps_arcsync.c
+++ b/drivers/misc/snps_accel/snps_arcsync.c
@@ -5,12 +5,13 @@
  * ARCsync - small module for synchronization and control of multiple
  * ARC processors assembled in a heterogeneous sub-system.
  *
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/delay.h>
 #include <linux/io.h>
 #include <linux/log2.h>
+#include <linux/init.h>
 #include <linux/module.h>
 #include <linux/of_address.h>
 #include <linux/of_platform.h>
@@ -633,12 +634,12 @@ arcsync_power_ctrl_cluster_group(struct device *dev, u32 clid, u32 grp, u32 cmd)
 }
 
 static struct arcsync_interrupt *
-arcsync_get_interrupt(struct arcsync_device *arcsync, u32 irq)
+arcsync_get_interrupt(struct arcsync_device *arcsync, u32 idx)
 {
 	int i;
 
 	for (i = 0; i < arcsync->num_irqs; i++) {
-		if (arcsync->irq[i].irqnum == irq)
+		if (arcsync->irq[i].idx == idx)
 			return &arcsync->irq[i];
 	}
 
@@ -648,7 +649,7 @@ arcsync_get_interrupt(struct arcsync_device *arcsync, u32 irq)
 /**
  * arcsync_set_interrupt_callback() - add callback for ARCSync interrupt handler
  * @dev: arcsync device handle
- * @irq: irq num
+ * @idx: arcsync irq index
  * @func: callback function pointer
  * @data: data pointer
  *
@@ -658,14 +659,14 @@ arcsync_get_interrupt(struct arcsync_device *arcsync, u32 irq)
  * Return: 0 on success or negative errno on failure.
  */
 static int
-arcsync_set_interrupt_callback(struct device *dev, u32 irq,
+arcsync_set_interrupt_callback(struct device *dev, u32 idx,
 			       intr_callback_t func, void *data)
 {
 	struct arcsync_callback *cb;
 	struct arcsync_interrupt *intr;
 	struct arcsync_device *arcsync = dev_get_drvdata(dev);
 
-	intr = arcsync_get_interrupt(arcsync, irq);
+	intr = arcsync_get_interrupt(arcsync, idx);
 	if (intr == NULL)
 		return -EINVAL;
 
@@ -686,7 +687,7 @@ arcsync_set_interrupt_callback(struct device *dev, u32 irq,
 /**
  * arcsync_remove_interrupt_callback() - remove interrupt handler callback
  * @dev: arcsync device handle
- * @irq: irq num
+ * @idx: arcsync irq index
  * @data: data pointer
  *
  * Remove the callback from an interrupt callback list.
@@ -694,7 +695,7 @@ arcsync_set_interrupt_callback(struct device *dev, u32 irq,
  * Return: 0 on success or negative errno on failure.
  */
 static int
-arcsync_remove_interrupt_callback(struct device *dev, u32 irq,
+arcsync_remove_interrupt_callback(struct device *dev, u32 idx,
 				  void *data)
 {
 	struct arcsync_interrupt *intr;
@@ -702,7 +703,7 @@ arcsync_remove_interrupt_callback(struct device *dev, u32 irq,
 	struct arcsync_callback *remove_cb = NULL;
 	struct arcsync_device *arcsync = dev_get_drvdata(dev);
 
-	intr = arcsync_get_interrupt(arcsync, irq);
+	intr = arcsync_get_interrupt(arcsync, idx);
 	if (intr == NULL)
 		return -EINVAL;
 
@@ -918,7 +919,7 @@ static int arcsync_probe(struct platform_device *pdev)
 			return ret;
 		}
 		arcsync->irq[i].irqnum = ret;
-		arcsync->irq[i].idx = i;
+		arcsync->irq[i].idx = i; /* arcsync irq index  */
 		arcsync->irq[i].arcsync = arcsync;
 		spin_lock_init(&arcsync->irq[i].callbacks_list_lock);
 		INIT_LIST_HEAD(&arcsync->irq[i].callbacks_list);

--- a/drivers/remoteproc/snps_accel/accel_rproc.c
+++ b/drivers/remoteproc/snps_accel/accel_rproc.c
@@ -2,9 +2,10 @@
 /*
  * Synopsys VPX/NPX remoteporc driver
  *
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
+#include <linux/init.h>
 #include <linux/module.h>
 #include <linux/firmware.h>
 #include <linux/iopoll.h>
@@ -12,6 +13,8 @@
 #include <linux/of_platform.h>
 #include <linux/platform_device.h>
 #include <linux/remoteproc.h>
+#include <linux/mm.h>
+#include <asm/cacheflush.h>
 
 #include "../remoteproc_elf_helpers.h"
 #include "../remoteproc_internal.h"
@@ -45,6 +48,22 @@ static int snps_accel_rproc_prepare(struct rproc *rproc)
 static int snps_accel_rproc_start(struct rproc *rproc)
 {
 	struct snps_accel_rproc *aproc = rproc->priv;
+	u32 num_mems = aproc->num_mems;
+	struct snps_accel_rproc_mem *mem = aproc->mem;
+
+#if defined(CONFIG_ARM64)
+	int i;
+	unsigned long start;
+	unsigned long end;
+
+	for (i = 0; i < num_mems; i++) {
+		start = (unsigned long)mem[i].virt_addr;
+		end = start + mem[i].size;
+
+		if (mem[i].is_ram == REGION_INTERSECTS)
+			dcache_clean_inval_poc(start, end); // ARM64-specific function
+	}
+#endif
 
 	if (aproc->data->start_core)
 		aproc->data->start_core(aproc);
@@ -267,6 +286,7 @@ static int snps_accel_rproc_of_get_mem(struct platform_device *pdev,
 	int num_mems;
 	int ret;
 	int i;
+	unsigned long flags;
 
 	/* Get accelerator aperture base */
 	ret = of_address_to_resource(dev->of_node->parent, 0, &shared_mem);
@@ -310,9 +330,15 @@ static int snps_accel_rproc_of_get_mem(struct platform_device *pdev,
 			return -EINVAL;
 		}
 
+		aproc->mem[i].is_ram = region_intersects(res->start, resource_size(res),
+								IORESOURCE_SYSTEM_RAM, IORES_DESC_NONE);
+		if (aproc->mem[i].is_ram == REGION_INTERSECTS)
+			flags = MEMREMAP_WB;
+		else
+			flags = MEMREMAP_WT;
+
 		aproc->mem[i].virt_addr = devm_memremap(dev, res->start,
-							resource_size(res),
-							MEMREMAP_WC);
+							resource_size(res), flags);
 		if (IS_ERR(aproc->mem[i].virt_addr)) {
 			dev_err(dev, "Failed to map shared memory (%pap)\n",
 				&res->start);
@@ -580,7 +606,18 @@ static struct platform_driver snps_accel_rproc_driver = {
 	},
 };
 
-module_platform_driver(snps_accel_rproc_driver);
+static int __init snps_accel_rproc_driver_init(void)
+{
+	return platform_driver_register(&snps_accel_rproc_driver);
+}
+
+static void __exit snps_accel_rproc_driver_exit(void)
+{
+	platform_driver_unregister(&snps_accel_rproc_driver);
+}
+
+late_initcall(snps_accel_rproc_driver_init);
+module_exit(snps_accel_rproc_driver_exit);
 
 MODULE_LICENSE("GPL v2");
 MODULE_DESCRIPTION("Synopsys VPX/NPX remote processor control driver");

--- a/drivers/remoteproc/snps_accel/accel_rproc.h
+++ b/drivers/remoteproc/snps_accel/accel_rproc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #ifndef __SNPS_ACCEL_RPROC_H__
@@ -17,12 +17,15 @@ struct snps_accel_rproc;
  * @phys_addr: CPU address used to access the memory region
  * @dev_addr: device address of the memory region from accelerator view
  * @size: size of the memory region
+ * @is_ram: region and system RAM intersects, disjoint, mixed,
+ *          see region_intersects() in linux/mm.h
  */
 struct snps_accel_rproc_mem {
 	void *virt_addr;
 	phys_addr_t phys_addr;
 	u32 dev_addr;
 	size_t size;
+	int is_ram;
 };
 
 /**


### PR DESCRIPTION
Driver changes to for ZynqMP ZCU104 FPGA (Linux v6.6 Cortex-A53 host with ARC VPX in FPGA):
- Updated device tree for ZynqMP ZCU104 FPGA
- Improved DMA support
- Added D-cache flush for firmware in system memory for SNPS accelerator rproc driver
- Fixed interrupt support and init order for SNPS accelerator app and arcsync driver
- Fixed shared memory mapping and init order for SNPS rproc driver