### PR TITLE
snps_accel_app: add arcsync interrupts assignment by index

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-mapping.h>
@@ -329,6 +329,10 @@ static irqreturn_t snps_accel_app_irq_callback(int irq, void *dev)
 	atomic_inc(&accel_app->irq_event);
 	wake_up_interruptible(&accel_app->wait);
 
+	dev_dbg(accel_app->device,
+			"ARCsync interrupt callback: irq %d, irqnum 0x%x, count %u\n",
+			irq, accel_app->irq_num, atomic_read(&accel_app->irq_event));
+
 	return IRQ_HANDLED;
 }
 
@@ -422,15 +426,16 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 
 	/* Add interrupt callback for ARCSync interrupt */
 	accel_app->irq_num = of_irq_get(node, 0);
+	of_property_read_u32(node, "snps,arcsync-irq-idx", &accel_app->irq_num);
 	if (accel_app->irq_num >= 0) {
 		ret = accel_app->ctrl.fn.set_interrupt_callback(accel_app->ctrl.dev,
 					accel_app->irq_num,
 					snps_accel_app_irq_callback, accel_app);
 		if (!ret) {
 			init_waitqueue_head(&accel_app->wait);
-			dev_dbg(accel_app->device, "App IRQ: %d\n", accel_app->irq_num);
+			dev_dbg(accel_app->device, "App IRQ idx: %d\n", accel_app->irq_num);
 		} else {
-			dev_warn(accel_app->device, "Not ARCSync IRQ %d\n", accel_app->irq_num);
+			dev_warn(accel_app->device, "Not ARCSync IRQ idx %d\n", accel_app->irq_num);
 			accel_app->irq_num = -EINVAL;
 		}
 	} else {


### PR DESCRIPTION
Assign an ARCSync interrupt to the snps application driver using an index of the respective interrupt in the array of assigned interrupts.