### PR TITLE
snps_accel: add arcsync interrupts assignment by index

### DIFF
--- a/arch/arc/boot/dts/haps_hs_npp.dts
+++ b/arch/arc/boot/dts/haps_hs_npp.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2016-2014 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2016-2025 Synopsys, Inc. (www.synopsys.com)
  */
 /dts-v1/;
 
@@ -94,7 +94,7 @@
 			compatible = "snps,accel-app";
 			reg = <0x20000000 0x10000000>;
 			snps,arcsync-ctrl = <&arcsync0>;
-			interrupts = <24>;
+			snps,arcsync-irq-idx = <0>;
 		};
 	};
 };


### PR DESCRIPTION
Assign an ARCSync interrupt to the snps application driver using an index of the respective interrupt in the array of assigned interrupts.