### PR TITLE
snps_accel_app: fix dma buffer management

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-mapping.h>
@@ -358,6 +358,7 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 	struct snps_accel_device *accel_dev = dev_get_drvdata(&pdev->dev);
 	struct resource ctrl;
 	struct resource shmem;
+	u32 dma_bits = 32;
 
 	ret = snps_accel_get_ctrl_mem(node, &ctrl);
 	if (ret < 0) {
@@ -414,11 +415,24 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 	}
 
 	accel_app->device->dma_mask = pdev->dev.dma_mask;
-	ret = dma_set_coherent_mask(accel_app->device, DMA_BIT_MASK(32));
+	ret = of_property_read_u32(node, "snps,dma-bits", &dma_bits);
+	if (ret) {
+		dev_warn(accel_app->device, "snps,dma-bits DTS property read error %d, use %u\n",
+				ret, dma_bits);
+	}
+	ret = dma_set_coherent_mask(accel_app->device, DMA_BIT_MASK(dma_bits));
 	if (ret) {
 		dev_err(accel_app->device, "No suitable coherent DMA available\n");
 		goto err_app_dev_init;
 	}
+	ret = dma_set_mask(accel_app->device, DMA_BIT_MASK(dma_bits));
+	if (ret) {
+		dev_err(accel_app->device, "No suitable DMA available\n");
+		goto err_app_dev_init;
+	}
+	dev_dbg(accel_app->device, "dma mask 0x%llx, coherent 0x%llx\n",
+			accel_app->device->dma_mask ? *accel_app->device->dma_mask : 0,
+			accel_app->device->coherent_dma_mask);
 
 	/* Add interrupt callback for ARCSync interrupt */
 	accel_app->irq_num = of_irq_get(node, 0);
@@ -524,6 +538,9 @@ static int snps_accel_probe(struct platform_device *pdev)
 	}
 	accel_dev->shared_base = res->start;
 	accel_dev->shared_size = resource_size(res);
+
+	dev_dbg(&pdev->dev, "shared memory start %pa, size %pa\n",
+			&accel_dev->shared_base, &accel_dev->shared_size);
 
 	dev_set_drvdata(&pdev->dev, accel_dev);
 	ret = snps_accel_create_devs(pdev);

--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-buf.h>
@@ -17,20 +17,21 @@ snps_accel_mbuf_alloc(struct snps_accel_mem_ctx *mem, size_t size,
 	struct page *page;
 	struct snps_accel_mem_buffer *mbuf = NULL;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
+	struct device *dmabuf_dev = mem->dev->parent;
 
 	mbuf = kzalloc(sizeof(*mbuf), GFP_KERNEL);
 	if (!mbuf)
 		return NULL;
 
 	/* Allocate buffer in direct memory */
-	page = dma_alloc_pages(mem->dev, PAGE_ALIGN(size), &mbuf->da,
-			       dma_dir, GFP_KERNEL | __GFP_NOWARN);
+	page = dma_alloc_pages(dmabuf_dev, PAGE_ALIGN(size), &mbuf->da,
+				dma_dir, GFP_KERNEL | __GFP_NOWARN);
 	if (!page) {
 		dev_err(mem->dev, "Failed to allocate contiguous memory for buffer\n");
 		return NULL;
 	}
 	mbuf->ctx = mem;
-	mbuf->dev = mem->dev;
+	mbuf->dev = dmabuf_dev;
 	mbuf->va = page_address(page);
 	mbuf->pa =  page_to_pfn(page) << PAGE_SHIFT;
 	mbuf->size = PAGE_ALIGN(size);
@@ -370,6 +371,9 @@ int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info)
 	info->addr = mbuf->da;
 	info->size = mbuf->size;
 
+	dev_dbg(mbuf->dev, "dmabuf info: va/pa/da %px/%pa/%pad, size %zu\n",
+			mbuf->va, &mbuf->pa, &mbuf->da, mbuf->size);
+
 	dma_buf_put(dmabuf);
 	return 0;
 }
@@ -385,6 +389,7 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 	struct snps_accel_mem_buffer *mbuf;
 	int ret;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
+	struct device *dmabuf_dev = mem->dev->parent;
 
 	dmabuf = dma_buf_get(fd);
 	if (IS_ERR_OR_NULL(dmabuf)) {
@@ -400,6 +405,7 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 	}
 
 	mbuf->dma_dir = DMA_BIDIRECTIONAL;
+	mbuf->dev = dmabuf_dev;
 	ret = snps_accel_dmabuf_attach_device(dmabuf, mem->dev,
 					      mbuf, mbuf->dma_dir);
 	if (ret != 0) {
@@ -412,7 +418,6 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 		goto err_notcontig;
 	}
 
-	mbuf->dev = mem->dev;
 	mbuf->fd = fd;
 	mbuf->dmabuf = dmabuf;
 	mbuf->size = dmabuf->size;


### PR DESCRIPTION
Use allocated DMA buffer DMA address for freeing the buffer instead of the mapped one since they can differ.

Associate allocated DMA buffer with the parent snps_accel device instead of the application device because the IOMMU is also associated with that device.

Add "snps,dma-bits" property in device tree for boot-time DMA mask configuration.