### PR TITLE
snps_accel: fix dma buffer management

### DIFF
--- a/arch/arc/boot/dts/haps_hs_npp.dts
+++ b/arch/arc/boot/dts/haps_hs_npp.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2016-2014 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2016-2025 Synopsys, Inc. (www.synopsys.com)
  */
 /dts-v1/;
 
@@ -95,6 +95,7 @@
 			reg = <0x20000000 0x10000000>;
 			snps,arcsync-ctrl = <&arcsync0>;
 			interrupts = <24>;
+			snps,dma-bits = <32>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -2,7 +2,7 @@
 /*
  * dts file for Xilinx ZynqMP
  *
- * (C) Copyright 2014 - 2025, Xilinx, Inc.
+ * (C) Copyright 2014 - 2019, Xilinx, Inc.
  *
  * Michal Simek <michal.simek@xilinx.com>
  *
@@ -717,7 +717,7 @@
 			compatible = "arm,mmu-500";
 			reg = <0x0 0xfd800000 0x0 0x20000>;
 			#iommu-cells = <1>;
-			status = "okay";
+			status = "disabled";
 			#global-interrupts = <1>;
 			interrupt-parent = <&gic>;
 			interrupts = <0 155 4>,
@@ -879,78 +879,6 @@
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_VIDEO1>,
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_VIDEO2>,
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_GRAPHICS>;
-		};
-	};
-
-	pl-bus {
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		compatible = "simple-bus";
-		ranges;
-
-		arcsync: arcsync_top@a4000000 {
-			clock-names = "arcsync_axi_clk", "arcsync_clk";
-			clocks = <&zynqmp_clk 71>, <&zynqmp_clk 71>;
-			compatible = "snps,arcsync";
-			interrupt-names = "h0host_irq";
-			interrupt-parent = <&gic>;
-			interrupts = <0 90 4>, /* GIC interrupt 122 - 32 = 90, irq_idx = 0, this interrupt is used by ARCsync for the host */
-				<0 89 4>; /* GIC interrupt 121 - 32 = 89, irq_idx = 1 */
-			reg = <0x00 0xa4000000 0x00 0x2000000>;
-			snps,host-core-id = <0x00>;
-			snps,host-cluster-id = <0x02>;
-		};
-
-		reserved-memory {
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
-
-			buffer@0 {
-				compatible = "removed-dma-pool";
-				no-map;
-				reg = <0x00 0x2b000000 0x00 0x200000>;
-			};
-		};
-
-		snps_accel@0 {
-			compatible = "snps,accel", "simple-bus";
-			#address-cells = <0x01>;
-			#size-cells = <0x01>;
-			/* Parent node address-celss and size-cells must be set to 2 */
-			/* 2MB shared memory: 1 - IPC memory, 2 - VPX firmware memory */
-			reg = <0x00 0x2b000000 0x00 0x200000>;
-			/* 1: 0x2B000000 - child address, 2: 0x0 0x2B000000 - parent address, 3: 0x200000 - child size */
-			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
-			#stream-id-cells = <0x01>;
-			/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
-			iommus = <&smmu 0x12c0>;
-
-			remoteproc_vpx@2B000000 {
-				compatible = "snps,vpx-rproc";
-				/* VPX firmware memory, must be the same as in the accel-ping linker script link_cmd.txt */
-				/* This size is the firmware footprint size */
-				reg = <0x2b000000 0x100000>;
-				firmware-name = "dmabuf-rw-app.elf";
-				snps,arcsync-ctrl = <&arcsync>;
-				snps,arcsync-core-id = <0x00>;
-				snps,arcsync-cluster-id = <0x01>;
-				/* Disable ARC core booting during Linux kernel booting for debugging purposes */
-				/* snps,auto-boot; */
-			};
-
-			app_vpx@0 {
-				compatible = "snps,accel-app";
-				/* IPC memory, must be the same as in SHR_MEM_START in VPX firmware */
-				reg = <0x2b100000 0x8000>;
-				snps,arcsync-ctrl = <&arcsync>;
-				/* Device tree interrupt 0x59(89) -> GIC interrupt 0x79(121) -> Host CPU interrupt 0x2C(44) */
-				/* Use irq index in arcsync interrupts array instead of the GIC irq id */
-				/* This index must be the same as the GIC interrupt 122 index in the arcsync node interrupts */
-				/* ARCsync v0c0arc_irq1_a -> VPX irq19_a in the FPGA bitfile */
-				snps,arcsync-irq-idx = <0x00>;
-				/* How many address bits the VPX master can use for DMA to system RAM */
-				snps,dma-bits = <0x1f>;
-			};
 		};
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -2,7 +2,7 @@
 /*
  * dts file for Xilinx ZynqMP
  *
- * (C) Copyright 2014 - 2019, Xilinx, Inc.
+ * (C) Copyright 2014 - 2025, Xilinx, Inc.
  *
  * Michal Simek <michal.simek@xilinx.com>
  *
@@ -717,7 +717,7 @@
 			compatible = "arm,mmu-500";
 			reg = <0x0 0xfd800000 0x0 0x20000>;
 			#iommu-cells = <1>;
-			status = "disabled";
+			status = "okay";
 			#global-interrupts = <1>;
 			interrupt-parent = <&gic>;
 			interrupts = <0 155 4>,
@@ -879,6 +879,78 @@
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_VIDEO1>,
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_VIDEO2>,
 			       <&zynqmp_dpdma ZYNQMP_DPDMA_GRAPHICS>;
+		};
+	};
+
+	pl-bus {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		arcsync: arcsync_top@a4000000 {
+			clock-names = "arcsync_axi_clk", "arcsync_clk";
+			clocks = <&zynqmp_clk 71>, <&zynqmp_clk 71>;
+			compatible = "snps,arcsync";
+			interrupt-names = "h0host_irq";
+			interrupt-parent = <&gic>;
+			interrupts = <0 90 4>, /* GIC interrupt 122 - 32 = 90, irq_idx = 0, this interrupt is used by ARCsync for the host */
+				<0 89 4>; /* GIC interrupt 121 - 32 = 89, irq_idx = 1 */
+			reg = <0x00 0xa4000000 0x00 0x2000000>;
+			snps,host-core-id = <0x00>;
+			snps,host-cluster-id = <0x02>;
+		};
+
+		reserved-memory {
+			#address-cells = <0x02>;
+			#size-cells = <0x02>;
+
+			buffer@0 {
+				compatible = "removed-dma-pool";
+				no-map;
+				reg = <0x00 0x2b000000 0x00 0x200000>;
+			};
+		};
+
+		snps_accel@0 {
+			compatible = "snps,accel", "simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			/* Parent node address-celss and size-cells must be set to 2 */
+			/* 2MB shared memory: 1 - IPC memory, 2 - VPX firmware memory */
+			reg = <0x00 0x2b000000 0x00 0x200000>;
+			/* 1: 0x2B000000 - child address, 2: 0x0 0x2B000000 - parent address, 3: 0x200000 - child size */
+			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
+			#stream-id-cells = <0x01>;
+			/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
+			iommus = <&smmu 0x12c0>;
+
+			remoteproc_vpx@2B000000 {
+				compatible = "snps,vpx-rproc";
+				/* VPX firmware memory, must be the same as in the accel-ping linker script link_cmd.txt */
+				/* This size is the firmware footprint size */
+				reg = <0x2b000000 0x100000>;
+				firmware-name = "dmabuf-rw-app.elf";
+				snps,arcsync-ctrl = <&arcsync>;
+				snps,arcsync-core-id = <0x00>;
+				snps,arcsync-cluster-id = <0x01>;
+				/* Disable ARC core booting during Linux kernel booting for debugging purposes */
+				/* snps,auto-boot; */
+			};
+
+			app_vpx@0 {
+				compatible = "snps,accel-app";
+				/* IPC memory, must be the same as in SHR_MEM_START in VPX firmware */
+				reg = <0x2b100000 0x8000>;
+				snps,arcsync-ctrl = <&arcsync>;
+				/* Device tree interrupt 0x59(89) -> GIC interrupt 0x79(121) -> Host CPU interrupt 0x2C(44) */
+				/* Use irq index in arcsync interrupts array instead of the GIC irq id */
+				/* This index must be the same as the GIC interrupt 122 index in the arcsync node interrupts */
+				/* ARCsync v0c0arc_irq1_a -> VPX irq19_a in the FPGA bitfile */
+				snps,arcsync-irq-idx = <0x00>;
+				/* How many address bits the VPX master can use for DMA to system RAM */
+				snps,dma-bits = <0x1f>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
Add "snps,dma-bits" property in device tree for boot-time DMA mask configuration.