### PR TITLE
Fix dma buffer attach

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (C) 2023 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2023-2025 Synopsys, Inc. (www.synopsys.com)
  */
 
 #include <linux/dma-buf.h>
@@ -115,7 +115,8 @@ static int snps_accel_dmabuf_attach_device(struct dma_buf *dmabuf,
 		return PTR_ERR(sgt);
 	}
 
-	mbuf->da = sg_dma_address(sgt->sgl);
+	if (mbuf->ctx == NULL)
+		mbuf->da = sg_dma_address(sgt->sgl);
 	mbuf->dmasgt = sgt;
 	mbuf->import_attach = dba;
 


### PR DESCRIPTION
The DMA buffer mapping is done twice in the driver. First, when the buffer is allocated and second when it is attached to the dmabuf framework. The second mapping can result in a different DMA address then obtained from the first mapping so that when that second DMA address is used for freeing the buffer this will give an error. This fix ensures the corrects DMA address is used to free the buffer.