### PR TITLE
Fix dmabuf info ioctl with imported buffers

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -116,7 +116,7 @@ snps_accel_do_dmabuf_alloc(struct snps_accel_file_priv *fpriv, char __user *argp
 }
 
 static int
-snps_accel_do_dmabuf_info(char __user *argp)
+snps_accel_do_dmabuf_info(struct snps_accel_file_priv *fpriv, char __user *argp)
 {
 	struct snps_accel_dmabuf_info data;
 	int ret;
@@ -125,7 +125,7 @@ snps_accel_do_dmabuf_info(char __user *argp)
 			  sizeof(struct snps_accel_dmabuf_info)))
 		return -EFAULT;
 
-	ret = snps_accel_app_dmabuf_info(&data);
+	ret = snps_accel_app_dmabuf_info(&fpriv->mem, &data);
 	if (ret)
 		return ret;
 
@@ -239,7 +239,7 @@ snps_accel_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		err = snps_accel_do_dmabuf_alloc(fpriv, argp);
 		break;
 	case SNPS_ACCEL_IOCTL_DMABUF_INFO:
-		err = snps_accel_do_dmabuf_info(argp);
+		err = snps_accel_do_dmabuf_info(fpriv, argp);
 		break;
 	case SNPS_ACCEL_IOCTL_DMABUF_IMPORT:
 		err = snps_accel_do_dmabuf_import(fpriv, argp);

--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -359,7 +359,7 @@ struct snps_accel_mem_buffer *snps_accel_app_dmabuf_create(struct snps_accel_mem
 	return mbuf;
 }
 
-int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info)
+int snps_accel_app_dmabuf_info(struct snps_accel_mem_ctx *mem, struct snps_accel_dmabuf_info *info)
 {
 	struct dma_buf *dmabuf;
 	struct snps_accel_mem_buffer *mbuf;
@@ -368,7 +368,13 @@ int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info)
 	if (!dmabuf)
 		return -EINVAL;
 
-	mbuf = (struct snps_accel_mem_buffer *)dmabuf->priv;
+	mbuf = snps_accel_dmabuf_find_by_fd(mem, info->fd);
+	if (!mbuf) {
+		dev_err(mem->dev, "Failed to find dmabuf with fd %d\n", info->fd);
+		dma_buf_put(dmabuf);
+		return -EINVAL;
+	}
+
 	info->addr = mbuf->da;
 	info->size = mbuf->size;
 

--- a/drivers/misc/snps_accel/snps_accel_mem.h
+++ b/drivers/misc/snps_accel/snps_accel_mem.h
@@ -56,7 +56,7 @@ void snps_accel_app_release_import(struct snps_accel_mem_ctx *mem);
 struct snps_accel_mem_buffer *snps_accel_app_dmabuf_create(struct snps_accel_mem_ctx *mem,
 							   u64 size, u32 dflags);
 void snps_accel_app_dmabuf_release(struct snps_accel_mem_buffer *mbuf);
-int snps_accel_app_dmabuf_info(struct snps_accel_dmabuf_info *info);
+int snps_accel_app_dmabuf_info(struct snps_accel_mem_ctx *mem, struct snps_accel_dmabuf_info *info);
 int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd);
 int snps_accel_app_dmabuf_detach(struct snps_accel_mem_ctx *mem, int fd);
 


### PR DESCRIPTION
The ```SNPS_ACCEL_IOCTL_DMABUF_INFO``` ioctl fails when the application passes a dma-buf file descriptor that was exported by another module and imported into the accel driver.
This patch fixes the issue by using ```snps_accel_dmabuf_find_by_fd()``` to correctly look up the dma-buf that was imported by the accel driver.