### PR TITLE
snps_accel_app: add iommu support

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -13,6 +13,11 @@
 #include <linux/platform_device.h>
 #include <linux/slab.h>
 
+#include <linux/of.h>
+#include <linux/of_iommu.h>
+#include <linux/iommu.h>
+#include <linux/device.h>
+
 #include <uapi/misc/snps_accel.h>
 #include "snps_accel_drv.h"
 
@@ -435,6 +440,19 @@ snps_accel_add_app(struct platform_device *pdev, struct device_node *node)
 			accel_app->device->dma_mask ? *accel_app->device->dma_mask : 0,
 			accel_app->device->coherent_dma_mask);
 
+#if IS_ENABLED(CONFIG_OF_IOMMU)
+	accel_app->device->bus = pdev->dev.bus;
+	accel_app->device->of_node = node;
+	if (IS_ERR_OR_NULL(of_iommu_configure(accel_app->device, node, NULL))) {
+		dev_warn(accel_app->device, "failed to configure IOMMU\n");
+	}
+	else {
+		if (accel_app->device->dma_ops == NULL && accel_app->device->dma_mask) {
+			iommu_setup_dma_ops(accel_app->device, 0, *accel_app->device->dma_mask);
+		}
+	}
+#endif
+
 	/* Add interrupt callback for ARCSync interrupt */
 	accel_app->irq_num = of_irq_get(node, 0);
 	if (accel_app->irq_num >= 0) {
@@ -503,6 +521,26 @@ static void snps_accel_release_app(struct snps_accel_app *accel_app)
 	if (accel_app->irq_num >= 0)
 		fn->remove_interrupt_callback(accel_app->ctrl.dev,
 					      accel_app->irq_num, accel_app);
+
+#if IS_ENABLED(CONFIG_IOMMU_API)
+	{
+		struct iommu_group *group;
+		struct iommu_domain *domain;
+
+		group = iommu_group_get(accel_app->device);
+		if (!group)
+			goto iommu_exit;
+
+		domain = iommu_get_domain_for_dev(accel_app->device);
+		if (domain) {
+			iommu_detach_device(domain, accel_app->device);
+			iommu_domain_free(domain);
+		}
+
+		iommu_exit:
+	}
+#endif
+
 	device_destroy(snps_accel_class, accel_app->devt);
 	cdev_del(&accel_app->cdev);
 }

--- a/drivers/misc/snps_accel/snps_accel_drv.c
+++ b/drivers/misc/snps_accel/snps_accel_drv.c
@@ -522,25 +522,6 @@ static void snps_accel_release_app(struct snps_accel_app *accel_app)
 		fn->remove_interrupt_callback(accel_app->ctrl.dev,
 					      accel_app->irq_num, accel_app);
 
-#if IS_ENABLED(CONFIG_IOMMU_API)
-	{
-		struct iommu_group *group;
-		struct iommu_domain *domain;
-
-		group = iommu_group_get(accel_app->device);
-		if (!group)
-			goto iommu_exit;
-
-		domain = iommu_get_domain_for_dev(accel_app->device);
-		if (domain) {
-			iommu_detach_device(domain, accel_app->device);
-			iommu_domain_free(domain);
-		}
-
-		iommu_exit:
-	}
-#endif
-
 	device_destroy(snps_accel_class, accel_app->devt);
 	cdev_del(&accel_app->cdev);
 }

--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -17,7 +17,7 @@ snps_accel_mbuf_alloc(struct snps_accel_mem_ctx *mem, size_t size,
 	struct page *page;
 	struct snps_accel_mem_buffer *mbuf = NULL;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
-	struct device *dmabuf_dev = mem->dev->parent;
+	struct device *dmabuf_dev = mem->dev;
 
 	mbuf = kzalloc(sizeof(*mbuf), GFP_KERNEL);
 	if (!mbuf)
@@ -396,7 +396,7 @@ int snps_accel_app_dmabuf_import(struct snps_accel_mem_ctx *mem, int fd)
 	struct snps_accel_mem_buffer *mbuf;
 	int ret;
 	struct snps_accel_file_priv *fpriv = to_snps_accel_file_priv(mem);
-	struct device *dmabuf_dev = mem->dev->parent;
+	struct device *dmabuf_dev = mem->dev;
 
 	dmabuf = dma_buf_get(fd);
 	if (IS_ERR_OR_NULL(dmabuf)) {


### PR DESCRIPTION
This changes adds support for the IOMMU subsystem for the application driver devices created dynamically in the driver probe() function.