### PR TITLE
snps_accel: add iommu support in device tree

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -921,9 +921,6 @@
 			reg = <0x00 0x2b000000 0x00 0x200000>;
 			/* 1: 0x2B000000 - child address, 2: 0x0 0x2B000000 - parent address, 3: 0x200000 - child size */
 			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
-			#stream-id-cells = <0x01>;
-			/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
-			iommus = <&smmu 0x12c0>;
 
 			remoteproc_vpx@2B000000 {
 				compatible = "snps,vpx-rproc";
@@ -951,6 +948,27 @@
 				interrupts = <0 90 4>;
 				/* How many address bits the VPX master can use for DMA to system RAM */
 				snps,dma-bits = <0x1f>;
+				#stream-id-cells = <0x01>;
+				/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
+				iommus = <&smmu 0x12c0>;
+			};
+
+			app_vpx@1 {
+				compatible = "snps,accel-app";
+				/* IPC memory, must be the same as in SHR_MEM_START in VPX firmware */
+				reg = <0x2b100000 0x8000>;
+				snps,arcsync-ctrl = <&arcsync>;
+				/* Device tree interrupt 0x59(89) -> GIC interrupt 0x79(121) -> Host CPU interrupt 0x2C(44) */
+				/* Use irq index in arcsync interrupts array instead of the GIC irq id */
+				interrupt-parent = <&gic>;
+				/* This interrupt must be the same as the GIC interrupt 122 index in the arcsync node interrupts */
+				/* ARCsync v0c0arc_irq1_a -> VPX irq19_a in the FPGA bitfile */
+				interrupts = <0 90 4>;
+				/* How many address bits the VPX master can use for DMA to system RAM */
+				snps,dma-bits = <0x1f>;
+				#stream-id-cells = <0x01>;
+				/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
+				iommus = <&smmu 0x12c1>;
 			};
 		};
 	};


### PR DESCRIPTION
This change adds the IOMMU support in the Zynq FPGA board device tree for the Synopsys accelerator device applications.