### PR TITLE
snps_accel: enable arc cbu iommu bypass

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -923,7 +923,9 @@
 			ranges = <0x2b000000 0x00 0x2b000000 0x200000>;
 			#stream-id-cells = <0x01>;
 			/* Stream ID = TBU4 (0b100 << 10) | S_AXI_HP1_FPD Master ID (0b1001 << 6) | AXI ID (0) */
-			iommus = <&smmu 0x12c0>;
+			/* VPX CBU master interface stream ID for the SMMU, connected to TBU3:
+			   TBU3 (0b11 << 10) | S_AXI_HP0_FPD Master ID (0b1010 << 6) | AXI ID (0) */
+			iommus = <&smmu 0x12c0>, <&smmu 0xE80>;
 
 			remoteproc_vpx@2B000000 {
 				compatible = "snps,vpx-rproc";

--- a/drivers/iommu/arm/arm-smmu/arm-smmu.c
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu.c
@@ -2,7 +2,7 @@
 /*
  * IOMMU API for ARM architected SMMU implementations.
  *
- * Copyright (C) 2013 ARM Limited
+ * Copyright (C) 2013-2025 ARM Limited
  *
  * Author: Will Deacon <will.deacon@arm.com>
  *
@@ -924,6 +924,9 @@ static void arm_smmu_write_s2cr(struct arm_smmu_device *smmu, int idx)
 		smmu->impl->write_s2cr(smmu, idx);
 		return;
 	}
+
+	if (smmu->smrs[idx].id == 0xE80)
+		s2cr->type = S2CR_TYPE_BYPASS;
 
 	reg = FIELD_PREP(ARM_SMMU_S2CR_TYPE, s2cr->type) |
 	      FIELD_PREP(ARM_SMMU_S2CR_CBNDX, s2cr->cbndx) |


### PR DESCRIPTION
This change enables the ARC CBU transactions to bypass the IOMMU. The ARM SMMU v2 driver is patched to enable these transactions for the bypass.