### PR TITLE
snps_accel_app: fix dma_buf_get() error handling

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -365,7 +365,7 @@ int snps_accel_app_dmabuf_info(struct snps_accel_mem_ctx *mem, struct snps_accel
 	struct snps_accel_mem_buffer *mbuf;
 
 	dmabuf = dma_buf_get(info->fd);
-	if (!dmabuf)
+	if (IS_ERR(dmabuf))
 		return -EINVAL;
 
 	mbuf = snps_accel_dmabuf_find_by_fd(mem, info->fd);


### PR DESCRIPTION
This changes eliminates kernel panic in case dma_buf_get() returns an error.