### PR TITLE
snps_accel_rproc: Fix decoder size calculation for 40-bit address space

### DIFF
--- a/drivers/remoteproc/snps_accel/npx_config.c
+++ b/drivers/remoteproc/snps_accel/npx_config.c
@@ -121,7 +121,7 @@ static void
 npx_config_aperture(void __iomem *ptr, int apidx, phys_addr_t apbase, const u32 apsize, int mst)
 {
 	phys_addr_t base = apbase >> 12;
-	u32 size = ~(apsize - 1) >> 12;
+	u32 size = (~(apsize - 1) >> 12) | 0xFF00000;
 
 	writel(base, ptr + NPX_CFG_DECBASE + apidx * 4);
 	writel(size, ptr + NPX_CFG_DECSIZE + apidx * 4);
@@ -133,7 +133,7 @@ npx_config_aperture_with_msk(void __iomem *ptr, int apidx, phys_addr_t apbase,
 			     const u32 apsize, int mst, u32 extra_size_msk)
 {
 	phys_addr_t base = apbase >> 12;
-	u32 size = ~(apsize - 1) >> 12;
+	u32 size = (~(apsize - 1) >> 12) | 0xFF00000;
 
 	size = size | (extra_size_msk >> 12);
 	writel(base, ptr + NPX_CFG_DECBASE + apidx * 4);


### PR DESCRIPTION
Update dec_size computation to correctly set upper address bits for 40-bit address space support. Previous formula:
```c
    dec_size = ~(size - 1) >> 12;
```
ignored bits [39:32], causing incorrect address matching and routing issues when high address bits differ from zero.

Fix by OR-ing with 0xFF00000 as per NPX memory map guidelines:
```c
    dec_size = (~(size - 1) >> 12) | 0xFF00000;
```
This change applies only to decoder size configuration.