### PR TITLE
snps_accel_app: fix dma_buf_put invalid pointer

### DIFF
--- a/drivers/misc/snps_accel/snps_accel_mem.c
+++ b/drivers/misc/snps_accel/snps_accel_mem.c
@@ -131,7 +131,7 @@ snps_accel_dmabuf_detach_device(struct snps_accel_mem_buffer *mbuf)
 		dma_buf_unmap_attachment(mbuf->import_attach, mbuf->dmasgt,
 					 mbuf->dma_dir);
 	dma_buf_detach(mbuf->dmabuf, mbuf->import_attach);
-	dma_buf_put(mbuf->import_attach->dmabuf);
+	dma_buf_put(mbuf->dmabuf);
 }
 
 static void snps_accel_dmabuf_op_release(struct dma_buf *dmabuf)


### PR DESCRIPTION
This change prevents from kernel panic caused by passing an invalid pointer to the dma_buf_put() function after freeing that pointer in the previous dma_buf_detach() function call.